### PR TITLE
Fixed pubspec.yaml to use test and not unittest and use test as a dev…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: levenshtein
 version: 1.0.2
 author: Conrad Kleinespel <conradk@conradk.com>
-homepage: https://github.com/conradkleinespel/levenshtein-dart
 description: An implementation of the Levenshtein distance algorithm
-dependencies:
-  unittest: "0.9.3"
+homepage: https://github.com/conradkleinespel/levenshtein-dart
+dev_dependencies:
+  test: any

--- a/test.dart
+++ b/test.dart
@@ -1,4 +1,4 @@
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'lib/levenshtein.dart';
 
 void main() {


### PR DESCRIPTION
Hi I updated the dependencies of the levenshtein-dart to use the new test farmework and not unittest and also use the test framework as a dev dependency. 